### PR TITLE
Fix Target attempting creating a schema for table

### DIFF
--- a/target_clickhouse/sinks.py
+++ b/target_clickhouse/sinks.py
@@ -117,6 +117,16 @@ class ClickhouseConnector(SQLConnector):
         _ = Table(table_name, meta, *columns, table_engine)
         meta.create_all(self._engine)
 
+    def prepare_schema(self, _: str) -> None:
+        """Create the target database schema.
+
+        In Clickhouse, a schema is a database, so this method is a no-op.
+
+        Args:
+            schema_name: The target schema name.
+        """
+        return
+
 class ClickhouseSink(SQLSink):
     """clickhouse target sink class."""
 


### PR DESCRIPTION
Clickhouse does not have a concept of Schema, so the target was failing as the default attempts to create a DB schema via SQLAlchemy. We can override this as a no-op.