### PR TITLE
Clickhouse ReplicatedMergeTree family support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ target-clickhouse --about --format=markdown
 |:---------------------|:--------:|:-------:|:------------|
 | sqlalchemy_url       | False    | None    | SQLAlchemy connection string |
 | table_name           | False    | None    | The name of the table to write to. |
+| engine_type          | False    | MergeTree | The engine type to use for the table. This must be one of the following engine types: MergeTree, ReplacingMergeTree, SummingMergeTree, AggregatingMergeTree, ReplicatedMergeTree, ReplicatedReplacingMergeTree, ReplicatedSummingMergeTree, ReplicatedAggregatingMergeTree. |
 | table_path           | False    | None    | The table path for replicated tables. This is required when using any of the replication engines. Check out the [documentation](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication#replicatedmergetree-parameters) for more information |
 | replica_name         | False    | None    | The `replica_name` for replicated tables. This is required when using any of the replication engines. |
 | cluster_name         | False    | None    | The cluster to create tables in. This is passed as the `clickhouse_cluster` argument when creating a table. [Documentation](https://clickhouse.com/docs/en/sql-reference/distributed-ddl) can be found here. |

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ target-clickhouse --about --format=markdown
 |:---------------------|:--------:|:-------:|:------------|
 | sqlalchemy_url       | False    | None    | SQLAlchemy connection string |
 | table_name           | False    | None    | The name of the table to write to. |
+| table_path           | False    | None    | The table path for replicated tables. This is required when using any of the replication engines. Check out the [documentation](https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication#replicatedmergetree-parameters) for more information |
+| replica_name         | False    | None    | The `replica_name` for replicated tables. This is required when using any of the replication engines. |
+| cluster_name         | False    | None    | The cluster to create tables in. This is passed as the `clickhouse_cluster` argument when creating a table. [Documentation](https://clickhouse.com/docs/en/sql-reference/distributed-ddl) can be found here. |
 | default_target_schema| False    | None    | The default target database schema name to use for all streams. |
 | stream_maps          | False    | None    | Config object for stream maps capability. For more information check out [Stream Maps](https://sdk.meltano.com/en/latest/stream_maps.html). |
 | stream_map_config    | False    | None    | User-defined config values to be used within map expressions. |

--- a/target_clickhouse/connectors.py
+++ b/target_clickhouse/connectors.py
@@ -71,7 +71,6 @@ class ClickhouseConnector(SQLConnector):
         primary_keys: list[str] | None = None,
         partition_keys: list[str] | None = None,
         as_temp_table: bool = False,  # noqa: FBT001, FBT002
-        engine_type: str = "MergeTree",  # Default to MergeTree engine
     ) -> None:
         """Create an empty target table, using Clickhouse Engine.
 
@@ -81,7 +80,6 @@ class ClickhouseConnector(SQLConnector):
             primary_keys: list of key properties.
             partition_keys: list of partition keys.
             as_temp_table: True to create a temp table.
-            engine_type: Clickhouse engine type. Must be on of the supported engine types.
         Raises:
             NotImplementedError: if temp tables are unsupported and as_temp_table=True.
             RuntimeError: if a variant schema is passed with no properties defined.
@@ -102,6 +100,13 @@ class ClickhouseConnector(SQLConnector):
         meta = MetaData(schema=None, bind=self._engine)
         columns: list[Column] = []
         primary_keys = primary_keys or []
+
+        # If config engine type is set, then use it instead of the default engine type.
+        if self.config.get("engine_type"):
+            engine_type = self.config.get("engine_type")
+        else:
+            engine_type = SupportedEngines.MERGE_TREE
+
         try:
             properties: dict = schema["properties"]
         except KeyError as e:

--- a/target_clickhouse/engine_class.py
+++ b/target_clickhouse/engine_class.py
@@ -1,0 +1,56 @@
+from clickhouse_sqlalchemy import engines
+from enum import Enum
+
+
+class SupportedEngines(str, Enum):
+    MERGE_TREE = "MergeTree"
+    REPLACING_MERGE_TREE = "ReplacingMergeTree"
+    SUMMING_MERGE_TREE = "SummingMergeTree"
+    AGGREGATING_MERGE_TREE = "AggregatingMergeTree"
+    REPLICATED_MERGE_TREE = "ReplicatedMergeTree"
+    REPLICATED_REPLACING_MERGE_TREE = "ReplicatedReplacingMergeTree"
+    REPLICATED_SUMMING_MERGE_TREE = "ReplicatedSummingMergeTree"
+    REPLICATED_AGGREGATING_MERGE_TREE = "ReplicatedAggregatingMergeTree"
+
+
+ENGINE_MAPPING = {
+    SupportedEngines.MERGE_TREE: engines.MergeTree,
+    SupportedEngines.REPLACING_MERGE_TREE: engines.ReplacingMergeTree,
+    SupportedEngines.SUMMING_MERGE_TREE: engines.SummingMergeTree,
+    SupportedEngines.AGGREGATING_MERGE_TREE: engines.AggregatingMergeTree,
+    SupportedEngines.REPLICATED_MERGE_TREE: engines.ReplicatedMergeTree,
+    SupportedEngines.REPLICATED_REPLACING_MERGE_TREE: engines.ReplicatedReplacingMergeTree,
+    SupportedEngines.REPLICATED_SUMMING_MERGE_TREE: engines.ReplicatedSummingMergeTree,
+    SupportedEngines.REPLICATED_AGGREGATING_MERGE_TREE: engines.ReplicatedAggregatingMergeTree,
+}
+
+
+def is_supported_engine(engine_type):
+    return engine_type in SupportedEngines.__members__.values()
+
+
+def get_engine_class(engine_type):
+    return ENGINE_MAPPING.get(engine_type)
+
+
+def create_engine_wrapper(engine_type, primary_keys, config: dict | None = None):
+    # check if engine type is in supported engines
+    if is_supported_engine(engine_type) is False:
+        raise ValueError(f"Engine type {engine_type} is not supported.")
+
+    engine_args = {"primary_key": primary_keys}
+    if config is not None:
+        if engine_type in (
+            SupportedEngines.REPLICATED_MERGE_TREE,
+            SupportedEngines.REPLICATED_REPLACING_MERGE_TREE,
+            SupportedEngines.REPLICATED_SUMMING_MERGE_TREE,
+            SupportedEngines.REPLICATED_AGGREGATING_MERGE_TREE,
+        ):
+            if config.get("table_path"):
+                engine_args["table_path"] = config.get("table_path")
+            if config.get("replica_name"):
+                engine_args["replica_name"] = config.get("replica_name")
+
+        engine_class = get_engine_class(engine_type)
+
+    return engine_class(**engine_args)


### PR DESCRIPTION
This PR allows users to use:

- ReplicatedMergeTree family support.
- Option to specify replica and cluster name. Along with that for the table_path which is required, we are using macros that are defined in the Zooper as default.
- Alter DDL support for on-cluster mode.