### PR TITLE
Allow no primary key in Target Clickhouse input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ ignore = [
     "D401", # First line should be in imperative mood
     "D407", # Missing dashed underline after section
     "FA100", # Forbidden import
-    "SLOT000", # Missing __slots__
 ]
 select = ["ALL"]
 src = ["target_clickhouse"]

--- a/target_clickhouse/engine_class.py
+++ b/target_clickhouse/engine_class.py
@@ -50,11 +50,11 @@ def create_engine_wrapper(
 
     engine_args: dict = {}
     if len(primary_keys) > 0:
-        engine_args |= {"primary_key": primary_keys}
+        engine_args["primary_key"] = primary_keys
     else:
         # If no primary keys are specified,
         # then Clickhouse expects the data to be indexed on all fields via tuple().
-        engine_args |= {"order_by": func.tuple()}
+        engine_args["order_by"] = func.tuple()
 
     if config is not None:
         if engine_type in (
@@ -65,10 +65,10 @@ def create_engine_wrapper(
         ):
             table_path: Optional[str] = config.get("table_path")
             if table_path is not None:
-                engine_args |= {"table_path": table_path }
+                engine_args["table_path"] = table_path
             replica_name: Optional[str] = config.get("replica_name")
             if replica_name is not None:
-                engine_args |= {"replica_name": replica_name }
+                engine_args["replica_name"] = replica_name
 
         engine_class = get_engine_class(engine_type)
 


### PR DESCRIPTION
If a Tap does not contain any primary key in the input stream to the target, instead default to a tuple() order_by statement as dictated by Clickhouse docs: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#:~:text=You%20can%20create%20a%20table,queries%2C%20set%20max_insert_threads%20%3D%201.