### PR TITLE
Use hard delete and update for activate version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shaped-target-clickhouse"
-version = "0.1.0"
+version = "0.1.1"
 description = "`target-clickhouse` is a Singer target for clickhouse, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Ben Theunissen"]


### PR DESCRIPTION
Do not want to use lightweight deletes and updates, as these operations are run only once at the start of the sync it is safe to use "hard" delete and update.