### PR TITLE
Attempt to stringify records that are not of the expected upstream type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shaped-target-clickhouse"
-version = "0.1.1"
+version = "0.1.2"
 description = "`target-clickhouse` is a Singer target for clickhouse, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Ben Theunissen"]


### PR DESCRIPTION
To workaround issues where tap schema is not correct, we can attempt to stringify JSON objects if the expected type is string.