### PR TITLE
Add unit test for date parsing and add manual trimming for invalid date types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shaped-target-clickhouse"
-version = "0.2.2"
+version = "0.2.3"
 description = "`target-clickhouse` is a Singer target for clickhouse, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Ben Theunissen"]

--- a/target_clickhouse/sinks.py
+++ b/target_clickhouse/sinks.py
@@ -9,8 +9,15 @@ import jsonschema.exceptions as jsonschema_exceptions
 import simplejson as json
 import sqlalchemy
 from pendulum import now
+from singer_sdk.helpers._compat import (
+    date_fromisoformat,
+    datetime_fromisoformat,
+    time_fromisoformat,
+)
 from singer_sdk.helpers._typing import (
     DatetimeErrorTreatmentEnum,
+    get_datelike_property_type,
+    handle_invalid_timestamp_in_record,
 )
 from singer_sdk.sinks import SQLSink
 from sqlalchemy.sql.expression import bindparam
@@ -174,9 +181,63 @@ class ClickhouseSink(SQLSink):
         except jsonschema_exceptions.ValidationError as e:
             if self.logger:
                 self.logger.exception(f"Record failed validation: {record}")
-            raise e # noqa: RERAISES
+            raise e # : RERAISES
 
         return record
+
+    def _parse_timestamps_in_record(
+        self,
+        record: dict,
+        schema: dict,
+        treatment: DatetimeErrorTreatmentEnum,
+    ) -> None:
+        """Parse strings to datetime.datetime values, repairing or erroring on failure.
+
+        Attempts to parse every field that is of type date/datetime/time. If its value
+        is out of range, repair logic will be driven by the `treatment` input arg:
+        MAX, NULL, or ERROR.
+
+        Args:
+            record: Individual record in the stream.
+            schema: TODO
+            treatment: TODO
+        """
+        for key, value in record.items():
+            if key not in schema["properties"]:
+                self.logger.warning("No schema for record field '%s'", key)
+                continue
+            datelike_type = get_datelike_property_type(schema["properties"][key])
+            if datelike_type:
+                date_val = value
+                try:
+                    if value is not None:
+                        if datelike_type == "time":
+                            date_val = time_fromisoformat(date_val)
+                        elif datelike_type == "date":
+                            # Trim time value from date fields.
+                            if "T" in date_val:
+                                # Split on T and get the first part.
+                                date_val = date_val.split("T")[0]
+                                self.logger.warning(
+                                    "Trimmed time value from date field '%s': %s",
+                                    key,
+                                    date_val,
+                                )
+                            date_val = date_fromisoformat(date_val)
+                        else:
+                            date_val = datetime_fromisoformat(date_val)
+                except ValueError as ex:
+                    date_val = handle_invalid_timestamp_in_record(
+                        record,
+                        [key],
+                        date_val,
+                        datelike_type,
+                        ex,
+                        treatment,
+                        self.logger,
+                    )
+                record[key] = date_val
+
 
 def pre_validate_for_string_type(
     record: dict,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,25 @@
 """Test Configuration."""
+from importlib.abc import Traversable
+from pathlib import Path
+
+from singer_sdk.testing.templates import TargetFileTestTemplate
 
 pytest_plugins = ()
+
+class TargetClickhouseFileTestTemplate(TargetFileTestTemplate):
+    """Base Target File Test Template.
+
+    Use this when sourcing Target test input from a .singer file.
+    """
+
+    @property
+    def singer_filepath(self) -> Traversable:
+        """Get path to singer JSONL formatted messages file.
+
+        Files will be sourced from `./target_test_streams/<test name>.singer`.
+
+        Returns
+            The expected Path to this tests singer file.
+        """
+        current_file_path = Path(__file__).resolve()
+        return current_file_path.parent / "target_test_streams" / f"{self.name}.singer"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 """Test Configuration."""
-from importlib.abc import Traversable
 from pathlib import Path
 
 from singer_sdk.testing.templates import TargetFileTestTemplate
@@ -13,7 +12,7 @@ class TargetClickhouseFileTestTemplate(TargetFileTestTemplate):
     """
 
     @property
-    def singer_filepath(self) -> Traversable:
+    def singer_filepath(self):
         """Get path to singer JSONL formatted messages file.
 
         Files will be sourced from `./target_test_streams/<test name>.singer`.

--- a/tests/target_test_cases.py
+++ b/tests/target_test_cases.py
@@ -1,0 +1,39 @@
+
+import datetime
+import logging
+
+from singer_sdk.testing.suites import TestSuite
+from sqlalchemy import text
+
+from tests.conftest import TargetClickhouseFileTestTemplate
+
+logger = logging.getLogger(__name__)
+
+class TestDateTypeTargetClickhouse(TargetClickhouseFileTestTemplate):
+    """Test date type can be ingested into Clickhouse."""
+
+    name = "date_type"
+
+    def validate(self) -> None:
+        """Validate the data in the target."""
+        connector = self.target.default_sink_class.connector_class(self.target.config)
+        result = connector.connection.execute(
+            statement=text("SELECT * FROM date_type"),
+        ).fetchall()
+        record_id_1 = 1
+        record_1 = [
+            record for record in result if record[0] == record_id_1
+        ][0]
+        assert record_1[1] == datetime.date(2024, 3, 15)
+        record_id_2 = 2
+        record_2 = [
+            record for record in result if record[0] == record_id_2
+        ][0]
+        assert record_2[1] == datetime.date(2024, 3, 16)
+
+custom_target_test_suite = TestSuite(
+    kind="target",
+    tests=[
+        TestDateTypeTargetClickhouse,
+    ],
+)

--- a/tests/target_test_cases.py
+++ b/tests/target_test_cases.py
@@ -21,14 +21,14 @@ class TestDateTypeTargetClickhouse(TargetClickhouseFileTestTemplate):
             statement=text("SELECT * FROM date_type"),
         ).fetchall()
         record_id_1 = 1
-        record_1 = [
+        record_1 = next(iter([
             record for record in result if record[0] == record_id_1
-        ][0]
+        ]))
         assert record_1[1] == datetime.date(2024, 3, 15)
         record_id_2 = 2
-        record_2 = [
+        record_2 = next(iter([
             record for record in result if record[0] == record_id_2
-        ][0]
+        ]))
         assert record_2[1] == datetime.date(2024, 3, 16)
 
 custom_target_test_suite = TestSuite(

--- a/tests/target_test_streams/date_type.singer
+++ b/tests/target_test_streams/date_type.singer
@@ -1,0 +1,4 @@
+{"type": "SCHEMA", "stream": "date_type", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "date": {"format": "date", "type": [ "null", "string" ] }}}}
+{"type": "RECORD", "stream": "date_type", "record": {"id": 1, "date": "2024-03-15"}}
+{"type": "RECORD", "stream": "date_type", "record": {"id": 2, "date": "2024-03-16T00:00:00+00:00"}}
+{"type": "RECORD", "stream": "date_type", "record": {"id": 3, "date": null}}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,6 +7,7 @@ import typing as t
 from singer_sdk.testing import get_target_test_class
 
 from target_clickhouse.target import TargetClickhouse
+from tests.target_test_cases import custom_target_test_suite
 
 TEST_CONFIG: dict[str, t.Any] = {
     "sqlalchemy_url": "clickhouse+http://default:@localhost:18123",
@@ -39,16 +40,20 @@ TEST_CONFIG_NATIVE: dict[str, t.Any] = {
 StandardTargetTests = get_target_test_class(
     target_class=TargetClickhouse,
     config=TEST_CONFIG,
+    custom_suites=[custom_target_test_suite],
 )
 
 
-class TestStandardTargetClickhouse(StandardTargetTests):  # type: ignore[misc, valid-type]
+class TestStandardTargetClickhouse(
+    StandardTargetTests, # type: ignore[misc, valid-type]
+):
     """Standard Target Tests."""
 
 
 SpreadTargetTests = get_target_test_class(
     target_class=TargetClickhouse,
     config=TEST_CONFIG_SPREAD,
+    custom_suites=[custom_target_test_suite],
 )
 
 


### PR DESCRIPTION
Meltano can send values of format `date` with time values included in the string, this causes Clickhouse to ignore the value when it fails to parse. Add unit test and manual code to trim for this case.