### PR TITLE
Cache the columns that are found in the clickhouse table

### DIFF
--- a/target_clickhouse/connectors.py
+++ b/target_clickhouse/connectors.py
@@ -4,6 +4,7 @@ import contextlib
 import typing
 from typing import TYPE_CHECKING
 
+import sqlalchemy as sa
 import sqlalchemy.types
 from clickhouse_sqlalchemy import (
     Table,
@@ -34,6 +35,7 @@ class ClickhouseConnector(SQLConnector):
     allow_column_alter: bool = True  # Whether altering column types is supported.
     allow_merge_upsert: bool = False  # Whether MERGE UPSERT is supported.
     allow_temp_tables: bool = True  # Whether temp tables are supported.
+    _cols_by_table = {} # cache of cols for a table
 
     def get_sqlalchemy_url(self, config: dict) -> str:
         """Generates a SQLAlchemy URL for clickhouse.
@@ -210,6 +212,16 @@ class ClickhouseConnector(SQLConnector):
 
         """
         return
+
+    def get_table_columns(
+        self,
+        full_table_name: str,
+        column_names: list[str] | None = None,
+    ) -> dict[str, sa.Column]:
+        '''override this method so we can cache it'''
+        if full_table_name not in self._cols_by_table:
+            self._cols_by_table[full_table_name] = super().get_table_columns(full_table_name)
+        return self._cols_by_table[full_table_name]
 
     def prepare_column(
             self,


### PR DESCRIPTION
The singer sdk SQLConnector assumes that get_table_columns is a pretty quick operation because it loops over every column in the schema an calls it twice. Once for getting the type `_get_column_type` and once for `column_exists`

Roundtrip requests to clickhouse to get this information are not super fast, and tables with a large amount of columns can take a very long time to initialize.

----

This change caches the results of this column lookup so that we only have to inspect them once. It is possible that this operation is not safe if the sink is re-used because of https://github.com/meltano/sdk/pull/2352 but given the simple use case that target clickhouse is using for this connector, this change is safe.