### PR TITLE
Fix nullable type handling for column types

### DIFF
--- a/target_clickhouse/connectors.py
+++ b/target_clickhouse/connectors.py
@@ -128,6 +128,17 @@ class ClickhouseConnector(SQLConnector):
         ):
             sql_type = clickhouse_sqlalchemy_types.Nullable(sql_type)
 
+        # Wrap any type in Nullable if the JSON schema allows null values
+        # and it's not already Nullable and not a primary key.
+        schema_type = jsonschema_type.get("type", [])
+        if (
+            isinstance(schema_type, list)
+            and "null" in schema_type
+            and not is_primary_key
+            and not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
+        ):
+            sql_type = clickhouse_sqlalchemy_types.Nullable(sql_type)
+
         return sql_type
 
     def create_empty_table(

--- a/tests/test_nullable_types.py
+++ b/tests/test_nullable_types.py
@@ -1,7 +1,6 @@
 """Tests for nullable type handling in to_sql_type."""
 
 from clickhouse_sqlalchemy import types as clickhouse_sqlalchemy_types
-from singer_sdk import typing as th
 
 from target_clickhouse.connectors import ClickhouseConnector
 
@@ -9,45 +8,57 @@ from target_clickhouse.connectors import ClickhouseConnector
 def _to_sql_type(jsonschema_type, is_primary_key=False):
     """Call to_sql_type as an unbound method — avoids full connector init."""
     return ClickhouseConnector.to_sql_type(
-        None, jsonschema_type, is_primary_key=is_primary_key
+        None,
+        jsonschema_type,
+        is_primary_key=is_primary_key,
     )
 
 
 class TestNullableTypeMapping:
+    """Tests for nullable type wrapping in ClickhouseConnector.to_sql_type."""
+
     def test_nullable_bool_returns_nullable(self):
+        """Nullable bool schema should produce Nullable(Bool)."""
         sql_type = _to_sql_type({"type": ["boolean", "null"]})
         assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_non_nullable_bool_returns_plain_bool(self):
+        """Non-nullable bool schema should not be wrapped."""
         sql_type = _to_sql_type({"type": ["boolean"]})
         assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_integer_returns_nullable(self):
+        """Nullable integer schema should produce Nullable(Int64)."""
         sql_type = _to_sql_type({"type": ["integer", "null"]})
         assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_string_returns_nullable(self):
+        """Nullable string schema should produce Nullable(String)."""
         sql_type = _to_sql_type({"type": ["string", "null"]})
         assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_number_returns_nullable(self):
+        """Nullable number schema should produce Nullable(Float)."""
         sql_type = _to_sql_type({"type": ["number", "null"]})
         assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_datetime_stays_nullable(self):
         """Datetime was already wrapped — should not double-wrap."""
         sql_type = _to_sql_type(
-            {"type": ["string", "null"], "format": "date-time"}
+            {"type": ["string", "null"], "format": "date-time"},
         )
         assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_primary_key_not_nullable(self):
+        """Primary key columns should never be Nullable."""
         sql_type = _to_sql_type(
-            {"type": ["boolean", "null"]}, is_primary_key=True
+            {"type": ["boolean", "null"]},
+            is_primary_key=True,
         )
         assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_non_nullable_integer_returns_int64(self):
+        """Non-nullable integer should produce Int64."""
         sql_type = _to_sql_type({"type": ["integer"]})
         assert isinstance(sql_type, clickhouse_sqlalchemy_types.Int64)
 

--- a/tests/test_nullable_types.py
+++ b/tests/test_nullable_types.py
@@ -1,0 +1,86 @@
+"""Tests for nullable type handling in to_sql_type."""
+
+import sqlalchemy.types
+from clickhouse_sqlalchemy import types as clickhouse_sqlalchemy_types
+from unittest.mock import MagicMock
+
+from target_clickhouse.connectors import ClickhouseConnector
+
+
+def _make_connector():
+    """Create a ClickhouseConnector with mocked config."""
+    connector = ClickhouseConnector.__new__(ClickhouseConnector)
+    connector.config = {}
+    connector.logger = MagicMock()
+    return connector
+
+
+class TestNullableTypeMapping:
+    def test_nullable_bool_returns_nullable(self):
+        connector = _make_connector()
+        sql_type = connector.to_sql_type({"type": ["boolean", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Expected Nullable, got {type(sql_type)}"
+        )
+
+    def test_non_nullable_bool_returns_plain_bool(self):
+        connector = _make_connector()
+        sql_type = connector.to_sql_type({"type": ["boolean"]})
+        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Expected non-Nullable, got {type(sql_type)}"
+        )
+
+    def test_nullable_integer_returns_nullable(self):
+        connector = _make_connector()
+        sql_type = connector.to_sql_type({"type": ["integer", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Expected Nullable, got {type(sql_type)}"
+        )
+
+    def test_nullable_string_returns_nullable(self):
+        connector = _make_connector()
+        sql_type = connector.to_sql_type({"type": ["string", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Expected Nullable, got {type(sql_type)}"
+        )
+
+    def test_nullable_number_returns_nullable(self):
+        connector = _make_connector()
+        sql_type = connector.to_sql_type({"type": ["number", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Expected Nullable, got {type(sql_type)}"
+        )
+
+    def test_nullable_datetime_stays_nullable(self):
+        """Datetime was already wrapped in Nullable — should not double-wrap."""
+        connector = _make_connector()
+        sql_type = connector.to_sql_type(
+            {"type": ["string", "null"], "format": "date-time"}
+        )
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Expected Nullable, got {type(sql_type)}"
+        )
+
+    def test_primary_key_not_nullable(self):
+        connector = _make_connector()
+        sql_type = connector.to_sql_type(
+            {"type": ["boolean", "null"]}, is_primary_key=True
+        )
+        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Primary keys should not be Nullable, got {type(sql_type)}"
+        )
+
+    def test_non_nullable_integer_returns_int64(self):
+        connector = _make_connector()
+        sql_type = connector.to_sql_type({"type": ["integer"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Int64), (
+            f"Expected Int64, got {type(sql_type)}"
+        )
+
+    def test_string_type_not_list(self):
+        """Handle case where type is a string, not a list."""
+        connector = _make_connector()
+        sql_type = connector.to_sql_type({"type": "boolean"})
+        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
+            f"Expected non-Nullable for string type, got {type(sql_type)}"
+        )

--- a/tests/test_nullable_types.py
+++ b/tests/test_nullable_types.py
@@ -2,15 +2,15 @@
 
 import sqlalchemy.types
 from clickhouse_sqlalchemy import types as clickhouse_sqlalchemy_types
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from target_clickhouse.connectors import ClickhouseConnector
 
 
 def _make_connector():
-    """Create a ClickhouseConnector with mocked config."""
+    """Create a ClickhouseConnector without full initialization."""
     connector = ClickhouseConnector.__new__(ClickhouseConnector)
-    connector.config = {}
+    connector._config = {}
     connector.logger = MagicMock()
     return connector
 

--- a/tests/test_nullable_types.py
+++ b/tests/test_nullable_types.py
@@ -1,86 +1,57 @@
 """Tests for nullable type handling in to_sql_type."""
 
-import sqlalchemy.types
 from clickhouse_sqlalchemy import types as clickhouse_sqlalchemy_types
-from unittest.mock import MagicMock, PropertyMock, patch
+from singer_sdk import typing as th
 
 from target_clickhouse.connectors import ClickhouseConnector
 
 
-def _make_connector():
-    """Create a ClickhouseConnector without full initialization."""
-    connector = ClickhouseConnector.__new__(ClickhouseConnector)
-    connector._config = {}
-    connector.logger = MagicMock()
-    return connector
+def _to_sql_type(jsonschema_type, is_primary_key=False):
+    """Call to_sql_type as an unbound method — avoids full connector init."""
+    return ClickhouseConnector.to_sql_type(
+        None, jsonschema_type, is_primary_key=is_primary_key
+    )
 
 
 class TestNullableTypeMapping:
     def test_nullable_bool_returns_nullable(self):
-        connector = _make_connector()
-        sql_type = connector.to_sql_type({"type": ["boolean", "null"]})
-        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Expected Nullable, got {type(sql_type)}"
-        )
+        sql_type = _to_sql_type({"type": ["boolean", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_non_nullable_bool_returns_plain_bool(self):
-        connector = _make_connector()
-        sql_type = connector.to_sql_type({"type": ["boolean"]})
-        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Expected non-Nullable, got {type(sql_type)}"
-        )
+        sql_type = _to_sql_type({"type": ["boolean"]})
+        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_integer_returns_nullable(self):
-        connector = _make_connector()
-        sql_type = connector.to_sql_type({"type": ["integer", "null"]})
-        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Expected Nullable, got {type(sql_type)}"
-        )
+        sql_type = _to_sql_type({"type": ["integer", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_string_returns_nullable(self):
-        connector = _make_connector()
-        sql_type = connector.to_sql_type({"type": ["string", "null"]})
-        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Expected Nullable, got {type(sql_type)}"
-        )
+        sql_type = _to_sql_type({"type": ["string", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_number_returns_nullable(self):
-        connector = _make_connector()
-        sql_type = connector.to_sql_type({"type": ["number", "null"]})
-        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Expected Nullable, got {type(sql_type)}"
-        )
+        sql_type = _to_sql_type({"type": ["number", "null"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_nullable_datetime_stays_nullable(self):
-        """Datetime was already wrapped in Nullable — should not double-wrap."""
-        connector = _make_connector()
-        sql_type = connector.to_sql_type(
+        """Datetime was already wrapped — should not double-wrap."""
+        sql_type = _to_sql_type(
             {"type": ["string", "null"], "format": "date-time"}
         )
-        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Expected Nullable, got {type(sql_type)}"
-        )
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_primary_key_not_nullable(self):
-        connector = _make_connector()
-        sql_type = connector.to_sql_type(
+        sql_type = _to_sql_type(
             {"type": ["boolean", "null"]}, is_primary_key=True
         )
-        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Primary keys should not be Nullable, got {type(sql_type)}"
-        )
+        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)
 
     def test_non_nullable_integer_returns_int64(self):
-        connector = _make_connector()
-        sql_type = connector.to_sql_type({"type": ["integer"]})
-        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Int64), (
-            f"Expected Int64, got {type(sql_type)}"
-        )
+        sql_type = _to_sql_type({"type": ["integer"]})
+        assert isinstance(sql_type, clickhouse_sqlalchemy_types.Int64)
 
     def test_string_type_not_list(self):
         """Handle case where type is a string, not a list."""
-        connector = _make_connector()
-        sql_type = connector.to_sql_type({"type": "boolean"})
-        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable), (
-            f"Expected non-Nullable for string type, got {type(sql_type)}"
-        )
+        sql_type = _to_sql_type({"type": "boolean"})
+        assert not isinstance(sql_type, clickhouse_sqlalchemy_types.Nullable)


### PR DESCRIPTION
## Summary
- Previously only date/datetime types were wrapped in `Nullable()` when the source schema allowed nulls
- Boolean, integer, float, and string columns with NULL values in the source DB were created as non-nullable in Clickhouse, silently converting NULLs to defaults (false, 0, empty string)
- Now checks the JSON schema `type` array for `"null"` and wraps any non-primary-key column in `Nullable()` accordingly

## Root cause
The `to_sql_type()` method in `connectors.py` had explicit `Nullable()` wrapping for `DATE`, `TIMESTAMP`, `TIME`, and `DATETIME` types, but no handling for `BOOLEAN`, `INTEGER`, `FLOAT`, `VARCHAR`, etc. The Singer SDK JSON schema represents nullable fields as `{"type": ["boolean", "null"]}` but this null indicator was ignored for non-date types.

## Impact
Affects any source table with nullable boolean/integer/float/string columns. Confirmed on Outdoorsy's `rentals` table: 18 boolean columns all created as `Bool` instead of `Nullable(Bool)`, with all source NULLs converted to `false`.

## Test plan
- [ ] Verify nullable bool column from Postgres creates `Nullable(Bool)` in Clickhouse
- [ ] Verify non-nullable columns remain non-nullable
- [ ] Verify primary key columns are not wrapped in Nullable